### PR TITLE
cleanup: allow jobs to stay in completed

### DIFF
--- a/.github/test.sh
+++ b/.github/test.sh
@@ -26,11 +26,6 @@ echo "Sleeping 1 minute waiting for scheduler deploy"
 sleep 60
 kubectl get pods
 
-# Note that exiting early here on success, we will test this further with the kubectl command TBA
-# since all pods are cleaned up. Or we need a way to distinguish between the terminated event
-# because the job finished and terminated otherwise (and needs the pod cleaned up)
-exit 0
-
 # This will get the fluence image (which has scheduler and sidecar), which should be first
 fluxnetes_pod=$(kubectl get pods -o json | jq -r .items[0].metadata.name)
 echo "Found fluxnetes pod ${fluxnetes_pod}"

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ SELECT group_name, group_size from pods_provisional;
    - we likely want to move assume pod outside of that schedule function, or ensure pod passed matches.
 - [ ] Optimize queries.
 - [ ] Restarting with postgres shouldn't have crashloopbackoff when the database isn't ready yet
+- [ ] need to cancel reservations and clear table at end of cycle
 - [ ] The queue should inherit (and return) the start time (when the pod was first seen) "start" in scheduler.go
 - Testing:
   - [ ] need to test duration / completion time works (run job with short duration, should be cancelled/cleaned up)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ After install (see the [README](../README.md)) you can create any abstraction (p
 | "fluxnetes.group-name" | The name of the group | fluxnetes-group-<namespace>-<name> |
 | "fluxnetes.group-size" | The size of the group | 1 |
 
-As you might guess, if you specify `fluxnetes` as the scheduler but don't provide any of the above, the defaults are used. This means a single pod becomes a single member group. 
+As you might guess, if you specify `fluxnetes` as the scheduler but don't provide any of the above, the defaults are used. This means a single pod becomes a single member group.
 
 ### Duration
 

--- a/kubernetes/pkg/fluxnetes/queries/queries.go
+++ b/kubernetes/pkg/fluxnetes/queries/queries.go
@@ -14,6 +14,7 @@ const (
 
 	// We need to get a single podspec for binding, etc
 	GetPodspecQuery = "select podspec from pods_provisional where group_name = $1 and name = $2 and namespace = $3;"
+	GetPodsQuery    = "select name, podspec from pods_provisional where group_name = $1 and namespace = $2;"
 
 	// This query should achieve the following
 	// 1. Select groups for which the size >= the number of pods we've seen

--- a/kubernetes/pkg/fluxnetes/strategy/provisional/provisional.go
+++ b/kubernetes/pkg/fluxnetes/strategy/provisional/provisional.go
@@ -19,28 +19,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/fluxnetes/types"
 )
 
-// Job Database Model we are retrieving for jobs
-// We will eventually want more than these three
-type JobModel struct {
-	GroupName string `db:"group_name"`
-	Namespace string `db:"namespace"`
-	GroupSize int32  `db:"group_size"`
-	Duration  int32  `db:"duration"`
-	Podspec   string `db:"podspec"`
-}
-
-// This collects the individual pod names and podspecs for the group
-type PodModel struct {
-	Name    string `db:"name"`
-	Podspec string `db:"podspec"`
-}
-
-// GroupModel provides the group name and namespace for groups at size
-type GroupModel struct {
-	GroupName string `db:"group_name"`
-	Namespace string `db:"namespace"`
-}
-
 // The provisional queue is a custom queue (to go along with a queue strategy attached
 // to a Fluxnetes.Queue) that handles ingesting single pods, and delivering them
 // in a particular way (e.g., sorted by timestamp, by group, etc). Since these
@@ -144,7 +122,7 @@ func (q *ProvisionalQueue) getReadyGroups(ctx context.Context, pool *pgxpool.Poo
 	}
 	defer rows.Close()
 
-	models, err := pgx.CollectRows(rows, pgx.RowToStructByName[JobModel])
+	models, err := pgx.CollectRows(rows, pgx.RowToStructByName[types.JobModel])
 	if err != nil {
 		klog.Infof("GetReadGroups Error: collect rows for groups at size: %s", err)
 		return nil, err
@@ -167,7 +145,7 @@ func (q *ProvisionalQueue) getReadyGroups(ctx context.Context, pool *pgxpool.Poo
 			return nil, err
 		}
 
-		pods, err := pgx.CollectRows(podRows, pgx.RowToStructByName[PodModel])
+		pods, err := pgx.CollectRows(podRows, pgx.RowToStructByName[types.PodModel])
 		if err != nil {
 			klog.Infof("SelectPodsQuery Error: collect rows for groups %s: %s", model.GroupName, err)
 			return nil, err

--- a/kubernetes/pkg/fluxnetes/strategy/workers/cleanup.go
+++ b/kubernetes/pkg/fluxnetes/strategy/workers/cleanup.go
@@ -226,8 +226,7 @@ func deleteFluxion(fluxID int64) error {
 	// see: https://riverqueue.com/docs/job-retries
 	conn, err := grpc.Dial("127.0.0.1:4242", grpc.WithInsecure())
 	if err != nil {
-		klog.Error("[Fluxnetes] AskFlux error connecting to server: %v\n", err)
-		return err
+		return fmt.Errorf("[Fluxnetes] AskFlux error connecting to server: %v\n", err)
 	}
 	defer conn.Close()
 
@@ -250,7 +249,8 @@ func deleteFluxion(fluxID int64) error {
 	// and possible already cancelled?
 	_, err = fluxion.Cancel(fluxionCtx, request)
 	if err != nil {
-		klog.Errorf("[Fluxnetes] Issue with cancel %s", err)
+		return fmt.Errorf("[Fluxnetes] Issue with cancel %s", err)
 	}
+	klog.Infof("[Fluxnetes] Successful cancel for jobid %d", fluxID)
 	return err
 }

--- a/kubernetes/pkg/fluxnetes/types/types.go
+++ b/kubernetes/pkg/fluxnetes/types/types.go
@@ -18,3 +18,25 @@ const (
 	// Unknown means some other error happened (usually not related to pod)
 	Unknown
 )
+
+// Job Database Model we are retrieving for jobs
+// We will eventually want more than these three
+type JobModel struct {
+	GroupName string `db:"group_name"`
+	Namespace string `db:"namespace"`
+	GroupSize int32  `db:"group_size"`
+	Duration  int32  `db:"duration"`
+	Podspec   string `db:"podspec"`
+}
+
+// This collects the individual pod names and podspecs for the group
+type PodModel struct {
+	Name    string `db:"name"`
+	Podspec string `db:"podspec"`
+}
+
+// GroupModel provides the group name and namespace for groups at size
+type GroupModel struct {
+	GroupName string `db:"group_name"`
+	Namespace string `db:"namespace"`
+}


### PR DESCRIPTION
We currently issue a kubernetes delete / terminate to all pods up to an owner on termination. This is only done assuming that we also need to completely delete the job group for fluxion. Instead, we can check or if the job pods are all finalized (terminated, whether successful or failed) before issuing the fluxion delete. This also allows us to not have to delete kubernetes objects and allow job objects to stay in their Completed state for further inspection.

I am also moving over the job model types into the types package for better organization.